### PR TITLE
Make class Address extendable

### DIFF
--- a/src/main/java/io/scalecube/net/Address.java
+++ b/src/main/java/io/scalecube/net/Address.java
@@ -6,7 +6,7 @@ import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-public final class Address {
+public class Address {
 
   public static final Address NULL_ADDRESS = Address.create("nullhost", 0);
 
@@ -16,9 +16,9 @@ public final class Address {
   private int port;
 
   /** Instantiates empty address for deserialization purpose. */
-  Address() {}
+  protected Address() {}
 
-  private Address(String host, int port) {
+  protected Address(String host, int port) {
     this.host = convertIfLocalhost(host);
     this.port = port;
   }


### PR DESCRIPTION
I've encountered an issue with custom Transport where I need to pass more info than host and port. Although I can pass additional info through headers, the messages that are sent by ScaleCube internally would lack these headers. So I propose making Address non-final for extension purposes